### PR TITLE
At least slightly more robust file.src handling

### DIFF
--- a/tasks/rasterize.js
+++ b/tasks/rasterize.js
@@ -93,7 +93,7 @@ module.exports = function (grunt) {
 
       async.eachLimit(output, options.limit, function (item, next) {
 
-        item.file.src = item.file.src[0];
+        item.file.src = String(item.file.src);
         var rootdir = path.dirname(item.file.src);
         var pngFileName = item.name || path.basename(item.file.src, ".svg") + '-' + item.width + ".png";
         var destDir = path.dirname(item.file.dest);


### PR DESCRIPTION
The problem is that the `async.eachLimit(output, options.limit, function
(item, next)` function appears to be recursive, so if >1 output file is
to be produced for each input file, then each time the function is being
called, that line above, `item.file.src = item.file.src[0];`, is
modifying `items.file.src`: first to make it a string from being an
array, and then to return just the first character of the string.  This
does indicate to me that something has changed in how Grunt expects
files to be handled.

I’ve tried searching for some documentation on what I surmise was a
change of API, or perhaps for guidance on the best patterns for handling
_n_ source files and _m_ destination files. However I have not been
successful, and I’m not au fait with async.js at all, so, for now, I
have reluctantly settled on at least making this a bit more of a robust
hack (I hope :-)) and simply making it convert the array to a string, so
that it doesn’t end up looking at just the first character of the source
file name and thus failing to read the source file.
